### PR TITLE
Update gemini_api.py

### DIFF
--- a/onetwo/backends/gemini_api.py
+++ b/onetwo/backends/gemini_api.py
@@ -53,7 +53,7 @@ _TokenHealingOption: TypeAlias = llm.TokenHealingOption
 DEFAULT_GENERATE_MODEL: Final[str] = 'models/gemini-2.0-flash'
 DEFAULT_MULTIMODAL_MODEL: Final[str] = 'models/gemini-2.0-flash'
 # input_token_limit=2048.
-DEFAULT_EMBED_MODEL: Final[str] = 'models/embedding-001'
+DEFAULT_EMBED_MODEL: Final[str] = 'models/gemini-embedding-001'
 
 # Refer to
 # https://ai.google.dev/api/python/google/ai/generativelanguage/HarmCategory.


### PR DESCRIPTION
Change the default embedding model, since `models/embedding-001` has been deprecated and will cause an issue when using the Gemini API.

When instantiating the Gemini API backend, the error:
```
File "<LOCAL_PATH>/python3.12/site-packages/onetwo/backends/gemini_api.py", line 326, in _verify_available_models
    raise ValueError(
ValueError: GeminiAPI._verify_available_models raised err:
Model models/embedding-001 not available.
```

unless explicitly overwritten by a different embedding model name.