### PR TITLE
Fix asyncio/uvloop event loop leak in asyncio_run_wrapper.

### DIFF
--- a/onetwo/core/iterating.py
+++ b/onetwo/core/iterating.py
@@ -87,23 +87,23 @@ def asyncio_run_wrapper(coroutine: Coroutine[Any, Any, T]) -> T:
   except RuntimeError:
     is_running = False
   if is_running:
-    loop = asyncio.new_event_loop()
-    context = contextvars.copy_context()
-    thr = _ThreadWithAsyncioLoop[T](
-        'Thread running an asyncio loop', coroutine, loop, context
-    )
-    thr.start()
-    try:
-      thr.join()
-    except BaseException as e:  # pylint: disable=broad-exception-caught
-      # The loop may still be running, so we need to explicitly stop it.
-      loop.stop()
-      thr.join()
-      raise e
-    if isinstance(thr.result, Exception):
-      raise thr.result
-    else:
-      return thr.result
+    with contextlib.closing(asyncio.new_event_loop()) as loop:
+      context = contextvars.copy_context()
+      thr = _ThreadWithAsyncioLoop[T](
+          'Thread running an asyncio loop', coroutine, loop, context
+      )
+      thr.start()
+      try:
+        thr.join()
+      except BaseException as e:  # pylint: disable=broad-exception-caught
+        # The loop may still be running, so we need to explicitly stop it.
+        loop.stop()
+        thr.join()
+        raise e
+      if isinstance(thr.result, Exception):
+        raise thr.result
+      else:
+        return thr.result
   else:
     return asyncio.run(coroutine)
 

--- a/onetwo/core/iterating_test.py
+++ b/onetwo/core/iterating_test.py
@@ -17,6 +17,7 @@ import contextvars
 import itertools
 import threading
 import time
+from unittest import mock
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -58,6 +59,27 @@ class IteratingTest(parameterized.TestCase):
       with self.subTest('direct_asyncio_fails'):
         with self.assertRaises(RuntimeError):
           asyncio.run(f(1))
+
+    asyncio.run(outer_wrapper())
+
+  def test_asyncio_run_wrapper_inside_loop_closes_loop(self):
+    async def outer_wrapper():
+      async def f():
+        return 42
+
+      original_new_event_loop = asyncio.new_event_loop
+      created_loops = []
+
+      def mock_new_event_loop():
+        loop = original_new_event_loop()
+        created_loops.append(loop)
+        return loop
+
+      with mock.patch('asyncio.new_event_loop', side_effect=mock_new_event_loop):
+        self.assertEqual(iterating.asyncio_run_wrapper(f()), 42)
+
+      self.assertEqual(len(created_loops), 1)
+      self.assertTrue(created_loops[0].is_closed())
 
     asyncio.run(outer_wrapper())
 


### PR DESCRIPTION
This PR fixes a resource and file descriptor leak in `asyncio_run_wrapper` that occurs when `onetwo.run` is called from within an already running event loop.

#### **Context & Problem**

When `asyncio_run_wrapper` is executed from an active event loop (`is_running = True`), it spawns a new event loop using `asyncio.new_event_loop()` and delegates execution to a new thread to run the coroutine without requiring to explicitly use `await`.

However, I noticed that the newly created event loop was never closed. In production environments—especially those configuring `uvloop` as the event loop policy—the unclosed loop instances leak underlying file descriptors (kqueue/epoll sockets), eventually leading to exhaustion of the process's file descriptor limit. I also saw this as a growing memory leak as `uvloop.Loop` instances built up over time.

#### **Solution**

I wrapped the newly created event loop using `contextlib.closing(asyncio.new_event_loop())` so that `loop.close()` is automatically called when the context exits. Since `thr.join()` blocks inside the context block until the thread finishes running, the loop is guaranteed to be inactive and safe to close when the context exits.

#### **Verification**

1. **Unit Tests**: I added `test_asyncio_run_wrapper_inside_loop_closes_loop` to `onetwo/core/iterating_test.py`, which patches `asyncio.new_event_loop`, runs the wrapper from a running event loop, and asserts that the captured event loop instance is successfully closed.
2. **Manual Leak Verification**: I ran a test script invoking `onetwo.run` 10 times in a nested async context under `uvloop`. 
   - **Before change**: Open FD count increased by 3 on every invocation (from 12 up to 42).
   - **After change**: Open FD count remained perfectly stable at 12.